### PR TITLE
2021 06 21

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 3.4.3 (unreleased)
 ------------------
 
+- Update faceted xml configuration. Add a workflow "draft" filter on projects. (Don't keep projects in draft state)
+  [boulch]
+- Add a project_directly_submitted checkbox field in ideabox controlpanel to choice is project can be directly submitted
+  [boulch]
 - Add campaign_emails field on campaign type to send mails only on to these campaign managers
   [boulch]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 3.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add campaign_emails field on campaign type to send mails only on to these campaign managers
+  [boulch]
 
 
 3.4.2 (2021-06-10)

--- a/src/ideabox/policy/browser/controlpanel.py
+++ b/src/ideabox/policy/browser/controlpanel.py
@@ -2,7 +2,6 @@
 
 from ideabox.policy import _
 from plone.app.registry.browser import controlpanel
-from plone.app.textfield import RichText
 from plone.app.z3cform.wysiwyg import WysiwygFieldWidget
 from plone.autoform import directives as form
 from z3c.form.interfaces import INPUT_MODE
@@ -28,6 +27,12 @@ class IIdeaBoxSettingsSchema(Interface):
         title=_(u"Legal information text"),
         required=False,
         description=_(u"Legal information text"),
+    )
+
+    project_directly_submitted = schema.Bool(
+        title=u"Projects directly submitted",
+        description=u"If checked, projects are public as soon as they are submitted.",
+        default=True,
     )
 
 

--- a/src/ideabox/policy/content/campaign.py
+++ b/src/ideabox/policy/content/campaign.py
@@ -13,8 +13,10 @@ class ICampaign(model.Schema):
     )
 
     emails = schema.TextLine(
-        title=_(u"Mails address"),
-        description=_(u'You can set many mails address separated with ";"'),
+        title=_(u"Email addresses"),
+        description=_(
+            u'Used to send notification when a new project is proposed by an user. Accept many email addresses separated with ";"'
+        ),
         required=False,
     )
 

--- a/src/ideabox/policy/content/campaign.py
+++ b/src/ideabox/policy/content/campaign.py
@@ -12,6 +12,12 @@ class ICampaign(model.Schema):
         title=_(u"Enable / Disable project submission"), default=False
     )
 
+    emails = schema.TextLine(
+        title=_(u"Mails address"),
+        description=_(u'You can set many mails address separated with ";"'),
+        required=False,
+    )
+
 
 @implementer(ICampaign)
 class Campaign(Container):

--- a/src/ideabox/policy/faceted/config/campaign.xml
+++ b/src/ideabox/policy/faceted/config/campaign.xml
@@ -116,7 +116,6 @@
    <property name="default">
     <element value="deposited"/>
     <element value="in_progress"/>
-    <element value="private"/>
     <element value="project_analysis"/>
     <element value="published"/>
     <element value="result_analysis"/>

--- a/src/ideabox/policy/faceted/config/campaign.xml
+++ b/src/ideabox/policy/faceted/config/campaign.xml
@@ -68,6 +68,15 @@
    <property name="hidezerocount">True</property>
    <property name="sortreversed">False</property>
   </criterion>
+  <criterion name="c6">
+   <property name="widget">project_sorting</property>
+   <property name="title">Tri</property>
+   <property name="vocabulary">ideabox.vocabularies.sort_project</property>
+   <property name="default">sortable_title</property>
+   <property name="position">top</property>
+   <property name="section">default</property>
+   <property name="hidden">False</property>
+  </criterion>
   <criterion name="c7">
    <property name="widget">select</property>
    <property name="title">Objectifs stratégiques</property>
@@ -96,14 +105,32 @@
    <property name="hidezerocount">True</property>
    <property name="sortreversed">False</property>
   </criterion>
-  <criterion name="c6">
-   <property name="widget">project_sorting</property>
-   <property name="title">Tri</property>
-   <property name="vocabulary">ideabox.vocabularies.sort_project</property>
-   <property name="default">sortable_title</property>
+  <criterion name="c9">
+   <property name="widget">checkbox</property>
+   <property name="title">wf_status</property>
+   <property name="index">review_state</property>
+   <property name="operator">or</property>
+   <property name="operator_visible">False</property>
+   <property name="vocabulary"></property>
+   <property name="catalog">portal_catalog</property>
+   <property name="default">
+    <element value="deposited"/>
+    <element value="in_progress"/>
+    <element value="private"/>
+    <element value="project_analysis"/>
+    <element value="published"/>
+    <element value="result_analysis"/>
+    <element value="selected"/>
+    <element value="vote"/>
+   </property>
    <property name="position">top</property>
    <property name="section">default</property>
-   <property name="hidden">False</property>
+   <property name="hidden">True</property>
+   <property name="count">False</property>
+   <property name="sortcountable">False</property>
+   <property name="hidezerocount">False</property>
+   <property name="maxitems">0</property>
+   <property name="sortreversed">False</property>
   </criterion>
  </criteria>
 </object>

--- a/src/ideabox/policy/form/project_submission.py
+++ b/src/ideabox/policy/form/project_submission.py
@@ -49,20 +49,19 @@ class ProjectSubmissionForm(Form):
 
     def send_mail(self, url):
         lang = api.portal.get_current_language()[:2]
-        email = api.portal.get_registry_record(
-            "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_manager_email",
-            default=None,
-        )
 
         campaign_email = self.context.emails
-
-        if campaign_email is None and email is None:
-            logger.warn("missing email for project submission notification")
-            return
 
         if campaign_email is not None:
             list_mail = campaign_email.split(";")
         else:
+            email = api.portal.get_registry_record(
+                "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_manager_email",
+                default=None,
+            )
+            if campaign_email is None and email is None:
+                logger.warn("missing email for project submission notification")
+                return
             list_mail = email.split(";")
 
         body = translate(
@@ -101,7 +100,7 @@ class ProjectSubmissionForm(Form):
         )
         project_directly_submitted = api.portal.get_registry_record(
             "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_directly_submitted",
-            default=None,
+            default=True,
         )
 
         if project_directly_submitted is True:

--- a/src/ideabox/policy/form/project_submission.py
+++ b/src/ideabox/policy/form/project_submission.py
@@ -60,7 +60,10 @@ class ProjectSubmissionForm(Form):
             logger.warn("missing email for project submission notification")
             return
 
-        list_mail = campaign_email.split(";") or email.split(";")
+        if campaign_email is not None:
+            list_mail = campaign_email.split(";")
+        else:
+            list_mail = email.split(";")
 
         body = translate(
             _(

--- a/src/ideabox/policy/form/project_submission.py
+++ b/src/ideabox/policy/form/project_submission.py
@@ -53,11 +53,14 @@ class ProjectSubmissionForm(Form):
             "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_manager_email",
             default=None,
         )
-        if email is None:
+
+        campaign_email = self.context.emails
+
+        if campaign_email is None and email is None:
             logger.warn("missing email for project submission notification")
             return
 
-        list_mail = email.split(";")
+        list_mail = campaign_email.split(";") or email.split(";")
 
         body = translate(
             _(

--- a/src/ideabox/policy/form/project_submission.py
+++ b/src/ideabox/policy/form/project_submission.py
@@ -99,9 +99,15 @@ class ProjectSubmissionForm(Form):
             container=container,
             original_author=api.user.get_current().id,
         )
-        execute_under_admin(
-            container, api.content.transition, obj=project_obj, transition="deposit"
+        project_directly_submitted = api.portal.get_registry_record(
+            "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_directly_submitted",
+            default=None,
         )
+
+        if project_directly_submitted is True:
+            execute_under_admin(
+                container, api.content.transition, obj=project_obj, transition="deposit"
+            )
         if data["project_image"]:
             execute_under_admin(
                 project_obj,

--- a/src/ideabox/policy/locales/fr/LC_MESSAGES/ideabox.policy.po
+++ b/src/ideabox/policy/locales/fr/LC_MESSAGES/ideabox.policy.po
@@ -63,7 +63,7 @@ msgstr "Campagne"
 msgid "Comment"
 msgstr "Commentaires"
 
-#: ../browser/controlpanel.py:37
+#: ../browser/controlpanel.py:42
 msgid "Configuration for ideabox product"
 msgstr "Configuration pour Ideabox"
 
@@ -113,7 +113,7 @@ msgstr "Modifier les dates de la ligne du temps"
 msgid "Email"
 msgstr ""
 
-#: ../browser/controlpanel.py:20
+#: ../browser/controlpanel.py:19
 msgid "Email address of the project manager"
 msgstr "Adresse e-mail du responsable des projets"
 
@@ -183,7 +183,7 @@ msgstr "J'accepte les Mentions Légales"
 
 #: ../export/export.py:195
 #: ../setuphandlers.py:106
-#: ../userdataschema.py:35
+#: ../userdataschema.py:38
 msgid "I am"
 msgstr "Je suis"
 
@@ -203,7 +203,11 @@ msgstr "Vue sommaire"
 msgid "Ideabox project"
 msgstr ""
 
-#: ../browser/controlpanel.py:21
+#: ../upgrades.py:232
+msgid "If checked, projects are public as soon as they are submitted."
+msgstr "Si cochée, les projet sont rendus publiques dès qu'ils sont soumis."
+
+#: ../browser/controlpanel.py:20
 msgid "If there are multiple email addresses, separate them with semicolons"
 msgstr "Si il y a plusieurs adresse email à renseigner séparez les par des points-virgules"
 
@@ -247,9 +251,9 @@ msgstr "Nom"
 msgid "Last name or institution"
 msgstr "Nom ou institution"
 
-#: ../browser/controlpanel.py:28
+#: ../browser/controlpanel.py:27
 #: ../profiles/default/registry.xml
-#: ../upgrades.py:201
+#: ../upgrades.py:204
 msgid "Legal information text"
 msgstr "Mentions légales"
 
@@ -262,7 +266,7 @@ msgid "Limit projects"
 msgstr "Limite d'élément affiché"
 
 #: ../setuphandlers.py:115
-#: ../upgrades.py:169
+#: ../upgrades.py:172
 msgid "Locality (Registration form)"
 msgstr "Localité (Formulaire d'inscription)"
 
@@ -270,6 +274,10 @@ msgstr "Localité (Formulaire d'inscription)"
 #: ../vocabularies.py:48
 msgid "MALE"
 msgstr "Homme"
+
+#: ../content/campaign.py:16
+msgid "Mails address"
+msgstr "Adresse e-mail"
 
 #: ../utils.py:100
 msgid "Mar"
@@ -287,7 +295,7 @@ msgstr "Mai"
 msgid "Negative rating "
 msgstr "Vote contre"
 
-#: ../form/project_submission.py:75
+#: ../form/project_submission.py:81
 msgid "New project submission"
 msgstr "Soumission d'un nouveau projet"
 
@@ -384,6 +392,11 @@ msgstr "Projet(s)"
 msgid "Projects"
 msgstr "Projets"
 
+#: ../profiles/default/registry.xml
+#: ../upgrades.py:230
+msgid "Projects directly submitted"
+msgstr "Soumettre directement le projet"
+
 #: ../browser/project.py:11
 msgid "Projects in progression"
 msgstr "Des projets en évolution"
@@ -413,7 +426,7 @@ msgid "Select a container"
 msgstr "Sélectionner un dossier"
 
 #: ../form/project_encoding.py:144
-#: ../form/project_submission.py:111
+#: ../form/project_submission.py:123
 #: ../form/vote_encoding.py:141
 msgid "Send"
 msgstr "Envoyer"
@@ -510,6 +523,10 @@ msgstr "Souhaitez-vous être tenu au courant de l’avancement du projet?"
 msgid "Yes"
 msgstr "Oui"
 
+#: ../content/campaign.py:17
+msgid "You can set many mails address separated with \";\""
+msgstr "Vous pouvez spécifier plusieurs adresses e-mails en les spérarants par \";\""
+
 #: ../browser/register.py:48
 msgid "You need to accept our legal terms and conditions."
 msgstr "Vous devez accepter les Mentions Légales pour pouvoir créer un compte."
@@ -531,7 +548,7 @@ msgid "diagnose and analysis"
 msgstr "Diagnostic et analyse"
 
 #. Default: "A new project has been created you can access it at the following url:\n              ${url}\n              "
-#: ../form/project_submission.py:63
+#: ../form/project_submission.py:69
 msgid "email_body_project_submission"
 msgstr ""
 "Un nouveau projet a été créé vous pouvez y accéder à l'url suivante :\n"
@@ -567,6 +584,6 @@ msgstr "projets"
 msgid "see_legal_conditions"
 msgstr "Voir les <a href=\"${legal_conditions_url}\">Mentions Légales</a>."
 
-#: ../userdataschema.py:31
+#: ../userdataschema.py:34
 msgid "zip code, locality or zip code and locality"
 msgstr "Code postal, localité, code postal et localité"

--- a/src/ideabox/policy/locales/ideabox.policy.pot
+++ b/src/ideabox/policy/locales/ideabox.policy.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-10 07:58+0000\n"
+"POT-Creation-Date: 2021-06-22 14:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: ideabox.policy\n"
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:43
 msgid ""
 msgstr ""
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: ../browser/controlpanel.py:37
+#: ../browser/controlpanel.py:42
 msgid "Configuration for ideabox product"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: ../browser/controlpanel.py:20
+#: ../browser/controlpanel.py:19
 msgid "Email address of the project manager"
 msgstr ""
 
@@ -189,7 +189,7 @@ msgstr ""
 
 #: ../export/export.py:195
 #: ../setuphandlers.py:106
-#: ../userdataschema.py:35
+#: ../userdataschema.py:38
 msgid "I am"
 msgstr ""
 
@@ -209,7 +209,11 @@ msgstr ""
 msgid "Ideabox project"
 msgstr ""
 
-#: ../browser/controlpanel.py:21
+#: ../upgrades.py:232
+msgid "If checked, projects are public as soon as they are submitted."
+msgstr ""
+
+#: ../browser/controlpanel.py:20
 msgid "If there are multiple email addresses, separate them with semicolons"
 msgstr ""
 
@@ -253,9 +257,9 @@ msgstr ""
 msgid "Last name or institution"
 msgstr ""
 
-#: ../browser/controlpanel.py:28
+#: ../browser/controlpanel.py:27
 #: ../profiles/default/registry.xml
-#: ../upgrades.py:201
+#: ../upgrades.py:204
 msgid "Legal information text"
 msgstr ""
 
@@ -268,13 +272,17 @@ msgid "Limit projects"
 msgstr ""
 
 #: ../setuphandlers.py:115
-#: ../upgrades.py:169
+#: ../upgrades.py:172
 msgid "Locality (Registration form)"
 msgstr ""
 
 #. Default: "Male"
 #: ../vocabularies.py:48
 msgid "MALE"
+msgstr ""
+
+#: ../content/campaign.py:16
+msgid "Mails address"
 msgstr ""
 
 #: ../utils.py:100
@@ -293,7 +301,7 @@ msgstr ""
 msgid "Negative rating "
 msgstr ""
 
-#: ../form/project_submission.py:75
+#: ../form/project_submission.py:81
 msgid "New project submission"
 msgstr ""
 
@@ -390,6 +398,11 @@ msgstr ""
 msgid "Projects"
 msgstr ""
 
+#: ../profiles/default/registry.xml
+#: ../upgrades.py:230
+msgid "Projects directly submitted"
+msgstr ""
+
 #: ../browser/project.py:11
 msgid "Projects in progression"
 msgstr ""
@@ -419,7 +432,7 @@ msgid "Select a container"
 msgstr ""
 
 #: ../form/project_encoding.py:144
-#: ../form/project_submission.py:111
+#: ../form/project_submission.py:123
 #: ../form/vote_encoding.py:141
 msgid "Send"
 msgstr ""
@@ -516,6 +529,10 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
+#: ../content/campaign.py:17
+msgid "You can set many mails address separated with \";\""
+msgstr ""
+
 #: ../browser/register.py:48
 msgid "You need to accept our legal terms and conditions."
 msgstr ""
@@ -537,7 +554,7 @@ msgid "diagnose and analysis"
 msgstr ""
 
 #. Default: "A new project has been created you can access it at the following url:\n              ${url}\n              "
-#: ../form/project_submission.py:63
+#: ../form/project_submission.py:69
 msgid "email_body_project_submission"
 msgstr ""
 
@@ -570,6 +587,6 @@ msgstr ""
 msgid "see_legal_conditions"
 msgstr ""
 
-#: ../userdataschema.py:31
+#: ../userdataschema.py:34
 msgid "zip code, locality or zip code and locality"
 msgstr ""

--- a/src/ideabox/policy/profiles/default/metadata.xml
+++ b/src/ideabox/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1009</version>
+  <version>1011</version>
   <dependencies>
     <dependency>profile-cioppino.twothumbs:default</dependency>
     <dependency>profile-eea.facetednavigation:default</dependency>

--- a/src/ideabox/policy/profiles/default/registry.xml
+++ b/src/ideabox/policy/profiles/default/registry.xml
@@ -125,6 +125,13 @@
     </field>
   </record>
 
+  <record name="ideabox.project_directly_submitted"
+        i18n:domain="ideabox.policy">
+    <field type="plone.registry.field.Bool">
+        <title i18n:translate="">Projects directly submitted</title>
+    </field>
+  </record>
+
   <!-- Plone bundle resources -->
   <records prefix="plone.resources/ideabox"
            interface='Products.CMFPlone.interfaces.IResourceRegistry'>

--- a/src/ideabox/policy/upgrades.py
+++ b/src/ideabox/policy/upgrades.py
@@ -9,7 +9,6 @@ from plone.registry import Record
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.i18n import translate
-from zope.schema.interfaces import IVocabularyFactory
 
 import logging
 
@@ -205,4 +204,32 @@ def to_1009(context):
     )
     records[
         "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.legal_information_text"
+    ] = record
+
+
+def to_1010(context):
+    """Add legal information text field in registry"""
+    registry = getUtility(IRegistry)
+    records = registry.records
+
+    if (
+        "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_directly_submitted"
+        in records
+    ):  # noqa
+        return
+
+    logger.info(
+        "Adding ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_directly_submitted to registry"
+    )  # noqa
+    record = Record(
+        field.Bool(
+            title=_(u"Projects directly submitted"),
+            default=True,
+            description=_(
+                u"If checked, projects are public as soon as they are submitted."
+            ),
+        )
+    )
+    records[
+        "ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_directly_submitted"
     ] = record

--- a/src/ideabox/policy/upgrades.zcml
+++ b/src/ideabox/policy/upgrades.zcml
@@ -74,4 +74,13 @@
     profile="ideabox.policy:default"
     handler=".upgrades.to_1009"
     />
+
+  <genericsetup:upgradeStep
+    source="1009"
+    destination="1010"
+    title="Adding ideabox.policy.browser.controlpanel.IIdeaBoxSettingsSchema.project_directly_submitted to registry"
+    profile="ideabox.policy:default"
+    handler=".upgrades.to_1010"
+    />
+
 </configure>

--- a/src/ideabox/policy/upgrades.zcml
+++ b/src/ideabox/policy/upgrades.zcml
@@ -83,4 +83,12 @@
     handler=".upgrades.to_1010"
     />
 
+  <genericsetup:upgradeStep
+    source="1010"
+    destination="1011"
+    title="Update faceted config for campaign"
+    profile="ideabox.policy:default"
+    handler=".upgrades.to_1011"
+    />
+
 </configure>

--- a/src/ideabox/policy/userdataschema.py
+++ b/src/ideabox/policy/userdataschema.py
@@ -28,7 +28,10 @@ class IEnhancedUserDataSchema(model.Schema):
     birthdate = schema.Date(title=_(u"Birthdate"), required=True)
 
     zip_code = schema.Choice(
-        title=_(u"Zip code / locality"), required=True, vocabulary=u"collective.taxonomy.locality", description=_(u"zip code, locality or zip code and locality")
+        title=_(u"Zip code / locality"),
+        required=True,
+        vocabulary=u"collective.taxonomy.locality",
+        description=_(u"zip code, locality or zip code and locality"),
     )
 
     iam = schema.Choice(


### PR DESCRIPTION
Salut Martin, 

Si tu veux bien, est-ce que tu pourrais faire un peu de code reviewing et me dire si c'est ok pour toi? 

Les modifications sont les suivantes : 
- ajout d'un champs campaign_emails sur les campagnes + cascading si pas de mail spécifié là (va chercher le mail dans la config de ideabox)
- Ajout d'un champs "project_directly_submitted" dans le controlpanel pour choisir de publié directement le projet ou le laisser en brouillon. (upgrade step pour la registry)
- Mie à jour de la config faceted pour ajouter un filtre sur le WF (on ne doit pas récupérer les projets qui restent en brouillon)
  Upgrade step également pour écraser les config des campagnes existantes.

Merci à toi.